### PR TITLE
[fix]: removed s3 bucket's acl as [AWS enforces Object Ownership with…

### DIFF
--- a/charts/infra/templates/cdn.yaml
+++ b/charts/infra/templates/cdn.yaml
@@ -18,7 +18,7 @@ spec:
   {{- $cfDefCB := default dict (index $cf "defaultCacheBehavior") }}
   domainName: {{ .Values.aws.cdn.domainName | quote }}
   bucketName: {{ .Values.aws.cdn.bucketName | quote }}
-  region: {{ default "eu-central-2" .Values.aws.cdn.region | quote }}
+  region: {{ default "eu-central-2" .Values.aws.region | quote }}
   tags:
 {{ include "infra.allTags" (dict "Values" .Values "section" .Values.aws.cdn) | indent 4 }}
   s3:

--- a/charts/infra/templates/rds.yaml
+++ b/charts/infra/templates/rds.yaml
@@ -20,7 +20,7 @@ metadata:
   name: {{ include "infra.rdsInstanceName" . }}
   namespace: {{ .Values.aws.rds.namespace | default .Release.Namespace }}
 spec:
-  region: {{ .Values.aws.rds.region | quote }}
+  region: {{ .Values.aws.region | quote }}
   allocatedStorage: {{ .Values.aws.rds.allocatedStorage | default 500 }}
   engine: {{ .Values.aws.rds.engine | default "postgres" | quote }}
   engineVersion: {{ .Values.aws.rds.engineVersion | default "15.12" | quote }}

--- a/charts/infra/templates/s3-buckets.yaml
+++ b/charts/infra/templates/s3-buckets.yaml
@@ -22,29 +22,6 @@ spec:
   providerConfigRef:
     name: {{ .Values.global.env }}
 
----
-apiVersion: {{ include "infra.s3ApiVersion" . }}
-kind: BucketACL
-metadata:
-  name: {{ include "infra.s3BucketName" . }}
-  namespace: {{ .Release.Namespace }}
-  annotations:
-    crossplane.io/external-name: {{ include "infra.s3BucketName" . }}
-  labels:
-{{ include "infra.labels" . | indent 4 }}
-spec:
-  forProvider:
-    acl: {{ .Values.aws.s3.acl | default "private" | quote }}
-    region: {{ .Values.aws.region | quote }}
-    bucketSelector:
-      matchLabels:
-        app.kubernetes.io/name: {{ include "infra.resourceName" (dict "global" .Values.global "Release" .Release) }}
-        app.kubernetes.io/instance: {{ include "infra.resourceName" (dict "global" .Values.global "Release" .Release) }}
-        app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-        helm.sh/chart: {{ printf "%s-%s" .Chart.Name (.Chart.Version | replace "+" "_") }}
-  providerConfigRef:
-    name: {{ .Values.global.env }}
 
 ---
 apiVersion: {{ include "infra.s3ApiVersion" . }}

--- a/charts/infra/values.yaml
+++ b/charts/infra/values.yaml
@@ -15,14 +15,13 @@ global:
 aws:
   enabled: true
   account: ""
-  region: ""
+  region: "eu-central-2"
   eksOidcId: ""
 
   s3:
     enabled: false
     bucketNameOverride: ""
-    acl: "private"
-    objectOwnership: "BucketOwnerPreferred"
+    objectOwnership: "BucketOwnerEnforced"
     lifeCycleConfiguration:
       enabled: false
       rule: []
@@ -57,7 +56,6 @@ aws:
     enabled: false
     instanceNameOverride: ""
     namespace: ""
-    region: ""
     dbName: ""
     instanceClass: db.t3.micro
     engine: postgres
@@ -103,7 +101,6 @@ aws:
     additional_tags: {}
     domainName: ""
     bucketName: ""
-    region: ""
     bucketPolicy:
       version: "2012-10-17"
     s3:


### PR DESCRIPTION
… ACLs disabled by default for new S3 buckets, via the ObjectOwnership = BucketOwnerEnforced setting](https://docs.aws.amazon.com/AmazonS3/latest/userguide/about-object-ownership.html). Any attempt to set or update ACLs (via PutBucketAcl) fails with 400: AccessControlListNotSupported - Removed aws.rds.region and aws.cd.region ans instead it now is aws.region

### Thank you for making `Swiss-Digital-Assets-Institute - Helm Charts` better

Please reference the issue this PR is fixing.

*Also verify you have:*

* [ ] Read the [contributions](../CONTRIBUTING.md) page.
* [ ] Read the [DCO](../DCO), if you are a first time contributor.
* [ ] Read the [code of conduct]([Code of Conduct](https://github.com/Swiss-Digital-Assets-Institute/.github/blob/main/CODE_OF_CONDUCT.md)).
