### PR TITLE
added lookup function in the rds to check if secrets already exists. …

### DIFF
--- a/charts/infra/templates/_helpers.tpl
+++ b/charts/infra/templates/_helpers.tpl
@@ -72,7 +72,7 @@ helm.sh/chart: {{ printf "%s-%s" .Chart.Name (.Chart.Version | replace "+" "_") 
 Generate a random password for use in secrets.
 */}}
 {{- define "infra.randomPassword" -}}
-{{- $letters := splitList "" "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@$*" -}}
+{{- $letters := splitList "" "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!#$*^()?[]" -}}
 {{- $len := 15 -}}
 {{- $password := "" -}}
 {{- range $i, $e := until $len }}

--- a/charts/infra/templates/rds.yaml
+++ b/charts/infra/templates/rds.yaml
@@ -1,10 +1,12 @@
 {{- if and (.Values.aws.rds.enabled | default false) (.Values.aws.enabled | default true) }}
+{{- $secretName := printf "%s-input-secret" (include "infra.rdsInstanceName" .) }}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace $secretName }}
+{{- if not $existing }}
 ---
-# Input password Secret - always rendered first via helm.sh/hook
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "infra.rdsInstanceName" . }}-input-secret
+  name: {{ $secretName }}
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": "pre-install"
@@ -14,6 +16,7 @@ metadata:
 type: Opaque
 stringData:
   password: "{{ include "infra.randomPassword" . }}"
+{{- end }}
 
 ---
 # RDS PgSQL Resource


### PR DESCRIPTION
PROBLEM
----------- 
every time a helm upgrade is performed, a new Secret was getting created and forcing an rds update. 

SOLUTION
-----------
- Added a [lookup function](https://helm.sh/docs/chart_template_guide/functions_and_pipelines/#using-the-lookup-function) to check if the secrets already exists.  If it exists then a new random password will not be generated again. On an empty cluster you’ll still see the Secret+hook emitted, but on subsequent upgrades (when that Secret already exists) the lookup will suppress the hook—and the RDS password will stay put.
- We can by default add a secret reference from the values file and the RDS will use the secret name specified. But the chat will still go ahead a create a secret. as it has the helm hook. 
- The idea is to use the helm functions for password generation is:
    - Crossplane composition doesn't yet have a function to generate random string. So we have to use helm for it. 
    - Avoid password commits in the git. 

REFERENCE
https://stackoverflow.com/questions/56170052/how-not-to-overwrite-randomly-generated-secrets-in-helm-templates 